### PR TITLE
Add ability to attach message on success

### DIFF
--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -54,8 +54,9 @@ class CronJobManager(object):
             cron_log = CronJobLog(code=cron_job.code, start_time=datetime.now())
             
             try:
-                cron_job.do()
+                msg = cron_job.do()
                 cron_log.is_success = True
+                cron_log.message = msg or ''
             except Exception, e:
                 cron_log.is_success = False
                 cron_log.message = traceback.format_exc()[-1000:]


### PR DESCRIPTION
The message was only saved upon exception. But sometimes we want to report some
additional info after running the cron job, like, how many records were
processed or something.
