### PR TITLE
Make cron job logs readonly for non-superuser

### DIFF
--- a/django_cron/admin.py
+++ b/django_cron/admin.py
@@ -11,4 +11,11 @@ class CronJobLogAdmin(admin.ModelAdmin):
     ordering = ('-start_time',)
     list_display = ('code', 'start_time', 'is_success')
 
+    def get_readonly_fields(self, request, obj=None):
+        if not request.user.is_superuser and obj is not None:
+            names = [f.name for f in CronJobLog._meta.fields if f.name != 'id']
+            return self.readonly_fields + tuple(names)
+        return self.readonly_fields
+
+
 admin.site.register(CronJobLog, CronJobLogAdmin)


### PR DESCRIPTION
These are logs, they aren't supposed to be edited, IMO.

Superuser is still a superuser, so we're not limiting his abilities.
