### PR TITLE
We should force database connection close, because django wont closeing ...

### DIFF
--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     # timezone added in Django 1.4
     from django_cron import timezone
+from django.db import close_connection
 
 
 DEFAULT_LOCK_TIME = 24 * 60 * 60  # 24 hours
@@ -55,6 +56,7 @@ class Command(BaseCommand):
         for cron_class in crons_to_run:
             run_cron_with_cache_check(cron_class, force=options['force'],
                 silent=options['silent'])
+        close_connection()
 
 
 def run_cron_with_cache_check(cron_class, force=False, silent=False):


### PR DESCRIPTION
Django not closing database connection for management command as well as for shells
So every management command should close connection by itself

http://stackoverflow.com/questions/16841505/django-resetting-postgres-connection/16863238#16863238
And I've created bug report on this issue in Django's bug tracker 
https://code.djangoproject.com/ticket/21255
