### PR TITLE
Handle db connection errors from CronJobManager

### DIFF
--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -74,8 +74,12 @@ def run_cron_with_cache_check(cron_class, force=False, silent=False):
         except:
             pass
         cache.set(cron_class.__name__, timezone.now(), timeout)
-        instance = cron_class()
-        CronJobManager.run(instance, force, silent)
+        try:
+            instance = cron_class()
+            CronJobManager.run(instance, force, silent)
+        except:
+            error = traceback.format_exc()
+            print('Error running cron job, got exception:\n%s' % error)
         cache.delete(cron_class.__name__)
     else:
         if not silent:


### PR DESCRIPTION
Wrap cron job instantiation and executing into try-except block to handle DB issues, syntax errors and other related problems that my occure way before instance.do() call. Need this to clear cache immidiately.
