### PR TITLE
Fixing `run_at_times` issues

### DIFF
--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -105,7 +105,7 @@ class CronJobManager(object):
                 actual_time = time.strptime("%s:%s" % (now.hour, now.minute), "%H:%M")
                 if actual_time >= user_time:
                     qset = CronJobLog.objects.filter(
-                        code=cron_job.code, ran_at_time=time_data).filter(
+                        code=cron_job.code, ran_at_time=time_data, is_success=True).filter(
                             Q(start_time__gt=now) |
                             Q(end_time__gte=now.replace(hour=0, minute=0,
                                                         second=0,

--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import timedelta, datetime
+from datetime import timedelta
 import traceback
 import time
 
@@ -100,9 +100,9 @@ class CronJobManager(object):
         if cron_job.schedule.run_at_times:
             for time_data in cron_job.schedule.run_at_times:
                 user_time = time.strptime(time_data, "%H:%M")
-                actual_time = time.strptime("%s:%s" % (datetime.now().hour, datetime.now().minute), "%H:%M")
+                actual_time = time.strptime("%s:%s" % (timezone.now().hour, timezone.now().minute), "%H:%M")
                 if actual_time >= user_time:
-                    qset = CronJobLog.objects.filter(code=cron_job.code, start_time__gt=datetime.today().date(), ran_at_time=time_data)
+                    qset = CronJobLog.objects.filter(code=cron_job.code, start_time__gt=timezone.now(), ran_at_time=time_data)
                     if not qset:
                         self.user_time = time_data
                         return True


### PR DESCRIPTION
Fixing issues with `run_at_times`:

1. Native datetimes were being used to compare to timezone aware datetimes on logs.
2. I would expect `run_at_times` to only run once per day at each time. This was not currently the case, have fixed.