### PR TITLE
Remove max_length from CronJobLog.message field

### DIFF
--- a/django_cron/migrations/0002_remove_max_length_from_CronJobLog_message.py
+++ b/django_cron/migrations/0002_remove_max_length_from_CronJobLog_message.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_cron', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cronjoblog',
+            name='message',
+            field=models.TextField(default='', blank=True),
+        ),
+    ]

--- a/django_cron/models.py
+++ b/django_cron/models.py
@@ -9,7 +9,7 @@ class CronJobLog(models.Model):
     start_time = models.DateTimeField(db_index=True)
     end_time = models.DateTimeField(db_index=True)
     is_success = models.BooleanField(default=False)
-    message = models.TextField(max_length=1000, blank=True)  # TODO: db_index=True
+    message = models.TextField(default='', blank=True)  # TODO: db_index=True
 
     """
     This field is used to mark jobs executed in exact time.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.4.4
+------
+
+    - Remove max_length from CronJobLog.message field.
+
+
 0.4.3
 ------
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ f.close()
 
 setup(
     name='django-cron',
-    version='0.4.3',
+    version='0.4.4',
     author='Sumit Chachra',
     author_email='chachra@tivix.com',
     url='http://github.com/tivix/django-cron',


### PR DESCRIPTION
Because `max_length` makes long exception stack is split.