### PR TITLE
Clarify that RUN_AT_TIMES uses local times

### DIFF
--- a/docs/sample_cron_configurations.rst
+++ b/docs/sample_cron_configurations.rst
@@ -40,7 +40,9 @@ This will run job at given hours:
 
         schedule = Schedule(run_at_times=RUN_AT_TIMES)
 
-Hour format is HH:MM (24h clock)
+Hour format is ``HH:MM`` (24h clock). ``django-cron`` will interpret
+these times in the local timezone of your site, as specified by
+the ``TIME_ZONE`` setting.
 
 You can also mix up both of these methods:
 


### PR DESCRIPTION
I'm interpreting #57 and 1d5278ed3c9d83c86ef3f0b4ee0c587ed38f5000 to mean that django-cron uses the local timezone specified in the settings file. If that's correct, this pull request updates the docs to clarify this question.