### PR TITLE
Exit with failure when cron classes can't be loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
 
 # Installer logs
 pip-log.txt

--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -2,7 +2,7 @@ from optparse import make_option
 import traceback
 from datetime import timedelta
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from django_cron import CronJobManager, get_class, get_current_time
 from django_cron.models import CronJobLog
@@ -35,8 +35,7 @@ class Command(BaseCommand):
             crons_to_run = [get_class(x) for x in cron_class_names]
         except Exception:
             error = traceback.format_exc()
-            self.stdout.write('Make sure these are valid cron class names: %s\n%s' % (cron_class_names, error))
-            return
+            raise CommandError('Make sure these are valid cron class names: %s\n%s' % (cron_class_names, error))
 
         for cron_class in crons_to_run:
             run_cron_with_cache_check(


### PR DESCRIPTION
The `runcrons` command is meant to be run unattended, therefore when it can't run due to `CRON_CLASSES` being wrong, the exit status must be set to failure. Otherwise the only indication is the output, which is typically discarded by `cron` and similar tools.

The current behavior can lead to very dire effects of cron jobs not running with no failures recorded in `CronJobLog`.
