### PR TITLE
added setting to run all cronjobs in parallel

### DIFF
--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -1,6 +1,7 @@
 from optparse import make_option
 import traceback
 from datetime import timedelta
+import threading
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -38,13 +39,29 @@ class Command(BaseCommand):
             self.stdout.write('Make sure these are valid cron class names: %s\n%s' % (cron_class_names, error))
             return
 
+        threads = []
         for cron_class in crons_to_run:
-            run_cron_with_cache_check(
-                cron_class,
-                force=options['force'],
-                silent=options['silent']
-            )
+            if getattr(settings,'DJANGO_CRON_MULTITHREADED',False):
+                ## run all cron jobs in parallel as thread
+                th = threading.Thread(
+                    target = run_cron_with_cache_check, 
+                    kwargs={
+                        "cron_class":cron_class,
+                        "force":options['force'],
+                        "silent":options['silent']
+                    }
+                )
+                th.start()
+                threads.append(th)
+            else:
+                run_cron_with_cache_check(
+                    cron_class,
+                    force=options['force'],
+                    silent=options['silent']
+                )
 
+        for th in threads:
+            th.join()
         clear_old_log_entries()
         close_connection()
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,5 +13,6 @@ Configuration
 
 **DJANGO_CRON_DELETE_LOGS_OLDER_THAN** - integer, number of days after which log entries will be clear (optional - if not set no entries will be deleted)
 
+**DJANGO_CRON_MULTITHREADED** - run all cronjobs in parallel by using threads, default: ``False``
 
 For more details, see :doc:`Sample Cron Configurations <sample_cron_configurations>` and :doc:`Locking backend <locking_backend>`


### PR DESCRIPTION
DJANGO_CRON_MULTITHREADED, default is False
Each job is run in a single thread, this does not
affect the check for temporal overlaps of the same cronjob