### PR TITLE
(docs) Tiny grammar fixes in README and introduction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,4 +27,4 @@ Documentation
 =============
 http://django-cron.readthedocs.org/en/latest/
 
-This opensource app is brought to you by Tivix, Inc. ( http://tivix.com/ )
+This open-source app is brought to you by Tivix, Inc. ( http://tivix.com/ )

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,6 +1,6 @@
 Introduction
 ============
 
-Django-cron lets you run Django/Python code on a recurring basis proving basic plumbing to track and execute tasks. The 2 most common ways in which most people go about this is either writing custom python scripts or a management command per cron (leads to too many management commands!). Along with that some mechanism to track success, failure etc. is also usually necesary.
+Django-cron lets you run Django/Python code on a recurring basis proving basic plumbing to track and execute tasks. The two most common ways in which most people go about this is either writing custom python scripts or a management command per cron (leads to too many management commands!). Along with that some mechanism to track success, failure etc. is also usually necesary.
 
 This app solves both issues to a reasonable extent. This is by no means a replacement for queues like Celery ( http://celeryproject.org/ ) etc.


### PR DESCRIPTION
Hello,

I noticed that the digit 2 was used where the word "two" could be used in the introduction
Also I updated "opensource" to "open-source" in the README
