### PR TITLE
Push failed cron job to logger as a warning

### DIFF
--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -191,6 +191,11 @@ class CronJobManager(object):
             try:
                 trace = "".join(traceback.format_exception(ex_type, ex_value, ex_traceback))
                 self.make_log(self.msg, trace, success=False)
+                logger.warning("Failed cron job: %s", self.cron_job.code, extra={
+                    'stacktrace': trace,
+                    'cron_job_class': self.cron_job_class,
+                    'cron_message': self.msg,
+                })
             except Exception as e:
                 err_msg = "Error saving cronjob log message: %s" % e
                 logger.error(err_msg)


### PR DESCRIPTION
Currently the problem is that failure logs only go to the database, but there is no possibility to route failures also to the loggers. Having failure logs go to the logger system allows routing them to things like Sentry for easy monitoring.
