### PR TITLE
Disable ordering by duration column. Fixes #86

### DIFF
--- a/django_cron/admin.py
+++ b/django_cron/admin.py
@@ -50,7 +50,6 @@ class CronJobLogAdmin(admin.ModelAdmin):
         return humanize_duration(obj.end_time - obj.start_time)
 
     humanize_duration.short_description = _("Duration")
-    humanize_duration.admin_order_field = 'duration'
 
 
 admin.site.register(CronJobLog, CronJobLogAdmin)


### PR DESCRIPTION
It was easier to remove sorting ability at this column rather than fix it (because it's not so useful opportunity).
