### PR TITLE
Django 1.10 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ python:
   - "2.7"
   - "3.4"
 env:
-  - DJANGO=1.7.11 DJANGO_SETTINGS_MODULE='settings_sqllite'
-  - DJANGO=1.7.11 DJANGO_SETTINGS_MODULE='settings_postgres'
-  - DJANGO=1.7.11 DJANGO_SETTINGS_MODULE='settings_mysql'
   - DJANGO=1.8.7 DJANGO_SETTINGS_MODULE='settings_sqllite'
   - DJANGO=1.8.7 DJANGO_SETTINGS_MODULE='settings_postgres'
   - DJANGO=1.8.7 DJANGO_SETTINGS_MODULE='settings_mysql'
   - DJANGO=1.9 DJANGO_SETTINGS_MODULE='settings_sqllite'
   - DJANGO=1.9 DJANGO_SETTINGS_MODULE='settings_postgres'
   - DJANGO=1.9 DJANGO_SETTINGS_MODULE='settings_mysql'
+  - DJANGO=1.10.1 DJANGO_SETTINGS_MODULE='settings_sqllite'
+  - DJANGO=1.10.1 DJANGO_SETTINGS_MODULE='settings_postgres'
+  - DJANGO=1.10.1 DJANGO_SETTINGS_MODULE='settings_mysql'
 addons:
   - postgresql: "9.3"
 install:

--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -17,6 +17,10 @@ DEFAULT_LOCK_TIME = 24 * 60 * 60  # 24 hours
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
+            'cron_classes',
+            nargs='*',
+        )
+        parser.add_argument(
             '--force',
             action='store_true',
             help='Force cron runs'
@@ -32,8 +36,9 @@ class Command(BaseCommand):
         Iterates over all the CRON_CLASSES (or if passed in as a commandline argument)
         and runs them.
         """
-        if args:
-            cron_class_names = args
+        cron_classes = options['cron_classes']
+        if cron_classes:
+            cron_class_names = cron_classes
         else:
             cron_class_names = getattr(settings, 'CRON_CLASSES', [])
 

--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -1,4 +1,3 @@
-from optparse import make_option
 import traceback
 from datetime import timedelta
 
@@ -16,10 +15,17 @@ DEFAULT_LOCK_TIME = 24 * 60 * 60  # 24 hours
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--force', action='store_true', help='Force cron runs'),
-        make_option('--silent', action='store_true', help='Do not push any message on console'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            help='Force cron runs'
+        )
+        parser.add_argument(
+            '--silent',
+            action='store_true',
+            help='Do not push any message on console'
+        )
 
     def handle(self, *args, **options):
         """

--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             'cron_classes',
-            nargs='*',
+            nargs='*'
         )
         parser.add_argument(
             '--force',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,15 @@
 Changelog
 =========
+0.5.0
+------
+
+    - Added support for Django 1.10
+
+    - Minimum Django version required is 1.8
+
+    - Use parser.add_argument() instead of optparse.make_option() in runcrons command
+
+
 0.4.6
 ------
 

--- a/settings_base.py
+++ b/settings_base.py
@@ -53,6 +53,15 @@ CACHES = {
     }
 }
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {},
+    },
+]
+
 ROOT_URLCONF = 'test_urls'
 SITE_ID = 1
 STATIC_URL = '/static/'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords='django cron',
     zip_safe=False,
     install_requires=[
-        'Django>=1.7.0',
+        'Django>=1.8.0',
         'django-common-helpers>=0.6.4'
     ],
     test_suite='runtests.runtests',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ f.close()
 
 setup(
     name='django-cron',
-    version='0.4.6',
+    version='0.5.0',
     author='Sumit Chachra',
     author_email='chachra@tivix.com',
     url='http://github.com/tivix/django-cron',

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,10 +1,9 @@
 # urls.py
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+]


### PR DESCRIPTION
Fixes:
#75 

+ [x] Management command arguments fix
+ [x] Make 1.8 minimum version and add 1.10 to Travis tests
+ [x] Fix unit tests for Django 1.10.1