### PR TITLE
Allow custom handlers to catch the cron job exceptions

### DIFF
--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -190,6 +190,8 @@ class CronJobManager(object):
                 logger.info(ex_value)
 
         elif ex_type is not None:
+            if not self.silent:
+                logger.exception("Error executing cron job")
             try:
                 trace = "".join(traceback.format_exception(ex_type, ex_value, ex_traceback))
                 self.make_log(self.msg, trace, success=False)


### PR DESCRIPTION
I wanted to be able to use custom handlers for exceptions instead of waiting for the FailedRunsNotificationCronJob to run
