### PR TITLE
Send mail when more than minimum of failures

### DIFF
--- a/django_cron/cron.py
+++ b/django_cron/cron.py
@@ -42,7 +42,7 @@ class FailedRunsNotificationCronJob(CronJobBase):
                     failures += 1
                     message += 'Job ran at %s : \n\n %s \n\n' % (job.start_time, job.message)
 
-            if failures == min_failures:
+            if failures >= min_failures:
                 send_mail(
                     '%s%s failed %s times in a row!' % (
                         FAILED_RUNS_CRONJOB_EMAIL_PREFIX,


### PR DESCRIPTION
The check `failures == min_failures` would work only when there was exactly the number of `min_failures` failures after this was run the last time. If the failing job ran more than once every half an hour this may have caused a situation where `failures > min_failures`.
