### PR TITLE
Prevent AttributeError when lock date is None.

### DIFF
--- a/django_cron/backends/lock/cache.py
+++ b/django_cron/backends/lock/cache.py
@@ -87,7 +87,7 @@ class CacheLock(DjangoCronJobLock):
 
     def get_running_lock_date(self):
         date = self.cache.get(self.lock_name)
-        if not timezone.is_aware(date):
+        if date and not timezone.is_aware(date):
             tz = timezone.get_current_timezone()
             date = timezone.make_aware(date, tz)
         return date


### PR DESCRIPTION
It is possible for the running lock date in the cache to be None if
another process released the lock before the current process fetched
the value from the cache.