### PR TITLE
Add run tolerance

### DIFF
--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -32,12 +32,13 @@ def get_current_time():
 
 
 class Schedule(object):
-    def __init__(self, run_every_mins=None, run_at_times=None, retry_after_failure_mins=None):
+    def __init__(self, run_every_mins=None, run_at_times=None, retry_after_failure_mins=None, run_tolerance_seconds=0):
         if run_at_times is None:
             run_at_times = []
         self.run_every_mins = run_every_mins
         self.run_at_times = run_at_times
         self.retry_after_failure_mins = retry_after_failure_mins
+        self.run_tolerance_seconds = run_tolerance_seconds
 
 
 class CronJobBase(object):
@@ -109,7 +110,7 @@ class CronJobManager(object):
                 pass
             if last_job:
                 if not last_job.is_success and cron_job.schedule.retry_after_failure_mins:
-                    if get_current_time() > last_job.start_time + timedelta(minutes=cron_job.schedule.retry_after_failure_mins):
+                    if get_current_time() + timedelta(seconds=cron_job.schedule.run_tolerance_seconds) > last_job.start_time + timedelta(minutes=cron_job.schedule.retry_after_failure_mins):
                         return True
                     else:
                         return False
@@ -124,7 +125,7 @@ class CronJobManager(object):
                 pass
 
             if self.previously_ran_successful_cron:
-                if get_current_time() > self.previously_ran_successful_cron.start_time + timedelta(minutes=cron_job.schedule.run_every_mins):
+                if get_current_time() + timedelta(seconds=cron_job.schedule.run_tolerance_seconds) > self.previously_ran_successful_cron.start_time + timedelta(minutes=cron_job.schedule.run_every_mins):
                     return True
             else:
                 return True

--- a/django_cron/tests.py
+++ b/django_cron/tests.py
@@ -38,6 +38,7 @@ class TestCase(TransactionTestCase):
     success_cron = 'test_crons.TestSucessCronJob'
     error_cron = 'test_crons.TestErrorCronJob'
     five_mins_cron = 'test_crons.Test5minsCronJob'
+    five_mins_with_tolerance_cron = 'test_crons.Test5minsWithToleranceCronJob'
     run_at_times_cron = 'test_crons.TestRunAtTimesCronJob'
     wait_3sec_cron = 'test_crons.Wait3secCronJob'
     does_not_exist_cron = 'ThisCronObviouslyDoesntExist'
@@ -84,6 +85,25 @@ class TestCase(TransactionTestCase):
 
         with freeze_time("2014-01-01 00:05:01"):
             call_command('runcrons', self.five_mins_cron)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count + 2)
+    
+    def test_runs_every_mins_with_tolerance(self):
+        logs_count = CronJobLog.objects.all().count()
+
+        with freeze_time("2014-01-01 00:00:00"):
+            call_command('runcrons', self.five_mins_with_tolerance_cron)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count + 1)
+
+        with freeze_time("2014-01-01 00:04:59"):
+            call_command('runcrons', self.five_mins_with_tolerance_cron)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count + 2)
+
+        with freeze_time("2014-01-01 00:05:01"):
+            call_command('runcrons', self.five_mins_with_tolerance_cron)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count + 2)
+
+        with freeze_time("2014-01-01 00:09:40"):
+            call_command('runcrons', self.five_mins_with_tolerance_cron)
         self.assertEqual(CronJobLog.objects.all().count(), logs_count + 2)
 
     def test_runs_at_time(self):

--- a/docs/sample_cron_configurations.rst
+++ b/docs/sample_cron_configurations.rst
@@ -56,6 +56,32 @@ You can also mix up both of these methods:
 
 This will run job every 2h plus one run at 6:30.
 
+
+Run tolerance feature
+---------------------
+
+You can specify ``RUN_TOLERANCE_SECONDS`` param.
+
+This parameter specifies a time window to run the job.
+
+For example, consider a job that runs every 5 minutes and last time it was run at 00:00:00. For example, ``runcrons`` command
+gets called every five minutes starting from 00:00:00.
+
+Without this parameter, the job will be run next time at 00:10:00.
+
+If ``RUN_TOLERANCE_SECONDS`` is set to non-zero value, the job will be run next time at 00:05:00. That makes job run period
+more precise.
+
+Usage example:
+
+.. code-block:: python
+
+    class MyCronJob(CronJobBase):
+        RUN_EVERY_MINS = 5
+
+        schedule = Schedule(run_every_mins=RUN_EVERY_MINS, run_tolerance_seconds=RUN_TOLERANCE_SECONDS)
+
+
 Allowing parallels runs
 -----------------------
 

--- a/test_crons.py
+++ b/test_crons.py
@@ -27,6 +27,14 @@ class Test5minsCronJob(CronJobBase):
         pass
 
 
+class Test5minsWithToleranceCronJob(CronJobBase):
+    code = 'test_run_every_mins'
+    schedule = Schedule(run_every_mins=5, run_tolerance_seconds=5)
+
+    def do(self):
+        pass
+
+
 class TestRunAtTimesCronJob(CronJobBase):
     code = 'test_run_at_times'
     schedule = Schedule(run_at_times=['0:00', '0:05'])


### PR DESCRIPTION
Add `run_tolerance_seconds` parameter to `Schedule` class.

This parameter specifies time window (in seconds) to run the job.

Basically, value of the parameter gets added to current time in the code.

For example, consider a job that runs every 5 minutes and last time it was run at 00:00:00. For example, `runcrons` command gets called every five minutes starting from 00:00:00.

Without this parameter, the job will be run next time at 00:10:00.

If `run_tolerance_seconds` is set to non-zero value, the job will be run next time at 00:05:00. That makes job run period more precise.

By default, run_tolerance_seconds is 0, so this does not affect existing jobs.