### PR TITLE
Add option to skip logging of successful jobs with no message

### DIFF
--- a/django_cron/__init__.py
+++ b/django_cron/__init__.py
@@ -150,7 +150,7 @@ class CronJobManager(object):
         return False
 
     def make_log(self, *messages, **kwargs):
-        skip_empty = getattr(settings, 'DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS', DEFAULT_LOG_EMPTY_MESSAGE_JOBS)
+        log_all = getattr(settings, 'DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS', DEFAULT_LOG_EMPTY_MESSAGE_JOBS)
 
         cron_log = self.cron_log
 
@@ -162,7 +162,7 @@ class CronJobManager(object):
         cron_log.ran_at_time = getattr(self, 'user_time', None)
         cron_log.end_time = get_current_time()
 
-        if skip_empty:
+        if not log_all:
             if cron_log.is_success and len(cron_log.message) == 0:
                 return
 

--- a/django_cron/tests.py
+++ b/django_cron/tests.py
@@ -36,6 +36,7 @@ class OutBuffer(object):
 class TestCase(TransactionTestCase):
 
     success_cron = 'test_crons.TestSucessCronJob'
+    success_with_message_cron = 'test_crons.TestSucessWithMessageCronJob'
     error_cron = 'test_crons.TestErrorCronJob'
     five_mins_cron = 'test_crons.Test5minsCronJob'
     run_at_times_cron = 'test_crons.TestRunAtTimesCronJob'
@@ -55,6 +56,24 @@ class TestCase(TransactionTestCase):
         logs_count = CronJobLog.objects.all().count()
         call_command('runcrons', self.error_cron, force=True)
         self.assertEqual(CronJobLog.objects.all().count(), logs_count + 1)
+
+    @override_settings(DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS=False)
+    def test_skip_empty_logs_failed(self):
+        logs_count = CronJobLog.objects.all().count()
+        call_command('runcrons', self.error_cron, force=True)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count + 1)
+
+    @override_settings(DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS=False)
+    def test_skip_empty_logs_success_with_message(self):
+        logs_count = CronJobLog.objects.all().count()
+        call_command('runcrons', self.success_with_message_cron, force=True)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count + 1)
+
+    @override_settings(DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS=False)
+    def test_skip_empty_logs_success_without_message(self):
+        logs_count = CronJobLog.objects.all().count()
+        call_command('runcrons', self.success, force=True)
+        self.assertEqual(CronJobLog.objects.all().count(), logs_count)
 
     def test_not_exists_cron(self):
         logs_count = CronJobLog.objects.all().count()

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,5 +13,6 @@ Configuration
 
 **DJANGO_CRON_DELETE_LOGS_OLDER_THAN** - integer, number of days after which log entries will be clear (optional - if not set no entries will be deleted)
 
+**DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS** - boolean, by default, django-cron logs all job results, even if the job succeeded with an empty message. Set this to False to skip logging if the job succeeded with no message. Default: ``True``
 
 For more details, see :doc:`Sample Cron Configurations <sample_cron_configurations>` and :doc:`Locking backend <locking_backend>`

--- a/test_crons.py
+++ b/test_crons.py
@@ -11,6 +11,13 @@ class TestSucessCronJob(CronJobBase):
         pass
 
 
+class TestSucessWithMessageCronJob(CronJobBase):
+    code = 'test_success_with_message_cron_job'
+    schedule = Schedule(run_every_mins=0)
+
+    def do(self):
+        return "test message"
+
 class TestErrorCronJob(CronJobBase):
     code = 'test_error_cron_job'
     schedule = Schedule(run_every_mins=0)


### PR DESCRIPTION
Add a new settings DJANGO_CRON_LOG_EMPTY_MESSAGE_JOBS that allows to skip logging of successful jobs with no message.

The default value is True, so this is fully backward compatible.