### PR TITLE
According to the Warning & HINTs of Django 3.2, We have to add the primary_key as BigAutoField

### DIFF
--- a/django_cron/models.py
+++ b/django_cron/models.py
@@ -6,6 +6,7 @@ class CronJobLog(models.Model):
     Keeps track of the cron jobs that ran etc. and any error
     messages if they failed.
     """
+    id = models.BigAutoField(primary_key=True)
     code = models.CharField(max_length=64, db_index=True)
     start_time = models.DateTimeField(db_index=True)
     end_time = models.DateTimeField(db_index=True)


### PR DESCRIPTION

django_cron.CronJobLog: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.