### PR TITLE
Update File Lock to respect job code instead of job name

### DIFF
--- a/django_cron/backends/lock/file.py
+++ b/django_cron/backends/lock/file.py
@@ -32,5 +32,5 @@ class FileLock(DjangoCronJobLock):
             # let it die if failed, can't run further anyway
             os.makedirs(path, exist_ok=True)
 
-        filename = self.job_name + '.lock'
+        filename = self.job_code + '.lock'
         return os.path.join(path, filename)


### PR DESCRIPTION
Helps run parallel crons on single instance