### PR TITLE
don't close connection in management command

### DIFF
--- a/django_cron/management/commands/runcrons.py
+++ b/django_cron/management/commands/runcrons.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
-from django.db import close_old_connections
 
 from django_cron import CronJobManager, get_class, get_current_time
 from django_cron.models import CronJobLog
@@ -67,7 +66,6 @@ class Command(BaseCommand):
             )
 
         clear_old_log_entries()
-        close_old_connections()
 
 
 def run_cron_with_cache_check(


### PR DESCRIPTION
This removes `close_old_connections()` at the end of the management command, because this prevents using `call_command` in the context of tests :

```python
from django.core.management import call_command
from django.test import TestCase

class MyTestCase(TestCase):
    def test_cron(self):
        ...
        call_command('runcrons')
        # test something else here
        ...
```
This fails with `psycopg2.InterfaceError: connection already closed`, as tests are run in transaction and django needs to rollback the transaction at the end of the test.

The `close_old_connections()` line was added in f7de4206413c73def89d83e996d821017eea2cbc back in 2013, I'm pretty sure in the mean time it's become useless.