### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/django_cron/tests.py
+++ b/django_cron/tests.py
@@ -114,9 +114,9 @@ class TestCase(TransactionTestCase):
         response = call(self.success_cron)
         self.assertReportedRun(test_crons.TestSucessCronJob, response)
         mock_do.assert_called_once()
-        self.assertEquals(1, CronJobLog.objects.count())
+        self.assertEqual(1, CronJobLog.objects.count())
         log = CronJobLog.objects.get()
-        self.assertEquals('message', log.message)
+        self.assertEqual('message', log.message)
         self.assertTrue(log.is_success)
 
     def test_runs_every_mins(self):
@@ -170,23 +170,23 @@ class TestCase(TransactionTestCase):
             
     def test_silent_produces_no_output_success(self):
         response = call(self.success_cron, silent=True)
-        self.assertEquals(1, CronJobLog.objects.count())
-        self.assertEquals('', response)
+        self.assertEqual(1, CronJobLog.objects.count())
+        self.assertEqual('', response)
 
     def test_silent_produces_no_output_no_run(self):
         with freeze_time("2014-01-01 00:00:00"):
             response = call(self.run_at_times_cron, silent=True)
-        self.assertEquals(1, CronJobLog.objects.count())
-        self.assertEquals('', response)
+        self.assertEqual(1, CronJobLog.objects.count())
+        self.assertEqual('', response)
 
         with freeze_time("2014-01-01 00:00:01"):
             response = call(self.run_at_times_cron, silent=True)
-        self.assertEquals(1, CronJobLog.objects.count())
-        self.assertEquals('', response)
+        self.assertEqual(1, CronJobLog.objects.count())
+        self.assertEqual('', response)
 
     def test_silent_produces_no_output_failure(self):
         response = call(self.error_cron, silent=True)
-        self.assertEquals('', response)
+        self.assertEqual('', response)
 
     def test_admin(self):
         password = 'test'


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268 