### PR TITLE
name locks by module_name.class_name for higher distinction

### DIFF
--- a/django_cron/backends/lock/base.py
+++ b/django_cron/backends/lock/base.py
@@ -26,7 +26,7 @@ class DjangoCronJobLock(object):
             * self.silent
         for you. The rest is backend-specific.
         """
-        self.job_name = cron_class.__name__
+        self.job_name = '.'.join([cron_class.__module__, cron_class.__name__])
         self.job_code = cron_class.code
         self.parallel = getattr(cron_class, 'ALLOW_PARALLEL_RUNS', False)
         self.silent = silent


### PR DESCRIPTION
Solution for problem described here https://github.com/Tivix/django-cron/issues/141