### PR TITLE
django 4.0 fixes

### DIFF
--- a/django_cron/admin.py
+++ b/django_cron/admin.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.contrib import admin
 from django.db.models import F
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_cron.models import CronJobLog
 from django_cron.helpers import humanize_duration

--- a/django_cron/helpers.py
+++ b/django_cron/helpers.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.template.defaultfilters import pluralize
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def humanize_duration(duration):


### PR DESCRIPTION
ugettext_lazy  is and aliases for gettext_lazy and the alias has been depreciated. 