### PR TITLE
Remove misleading link from deprecation notice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ===========
 Deprecated
 ===========
-Please use https://github.com/iMerica/dj-rest-auth as this project is no longer maintained. Thanks!
+This project is no longer maintained.
 
 ===========
 django-cron


### PR DESCRIPTION
Removed link to fork of a different deprecated Tivix project.

Resolves #177