### PR TITLE
Minimal number of failures configurable through settings

### DIFF
--- a/django_cron/cron.py
+++ b/django_cron/cron.py
@@ -28,6 +28,7 @@ class FailedRunsNotificationCronJob(CronJobBase):
         min_num_failures_default = getattr(
             settings, 'DJANGO_CRON_MIN_NUM_FAILURES_DEFAULT', 10
         )
+        
         for cron in crons_to_check:
 
             min_failures = getattr(cron, 'MIN_NUM_FAILURES', min_num_failures_default)

--- a/django_cron/cron.py
+++ b/django_cron/cron.py
@@ -26,7 +26,7 @@ class FailedRunsNotificationCronJob(CronJobBase):
         )
 
         min_num_failures_default = getattr(
-            settings, 'CRON_MIN_NUM_FAILURES_DEFAULT', 10
+            settings, 'DJANGO_CRON_MIN_NUM_FAILURES_DEFAULT', 10
         )
         for cron in crons_to_check:
 

--- a/django_cron/cron.py
+++ b/django_cron/cron.py
@@ -25,9 +25,12 @@ class FailedRunsNotificationCronJob(CronJobBase):
             settings, 'FAILED_RUNS_CRONJOB_EMAIL_PREFIX', ''
         )
 
+        min_num_failures_default = getattr(
+            settings, 'CRON_MIN_NUM_FAILURES_DEFAULT', 10
+        )
         for cron in crons_to_check:
 
-            min_failures = getattr(cron, 'MIN_NUM_FAILURES', 10)
+            min_failures = getattr(cron, 'MIN_NUM_FAILURES', min_num_failures_default)
             jobs = CronJobLog.objects.filter(code=cron.code).order_by('-end_time')[
                 :min_failures
             ]


### PR DESCRIPTION
Minimal number of failures of a cronjob should be an overridable default.