### PR TITLE
Adding back django-common-helper as 0.9.2 to fix missing dependancy

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,3 @@
 Django==4.0.4
+django-common-helpers==0.9.2
 -e ../

--- a/docs/sample_cron_configurations.rst
+++ b/docs/sample_cron_configurations.rst
@@ -158,7 +158,7 @@ FailedRunsNotificationCronJob
 
 This example cron check last cron jobs results. If they were unsuccessfull 10 times in row, it sends email to user.
 
-Install required dependencies: ``Django>=3.2.0``.
+Install required dependencies: ``Django>=3.2.0``, ``django-common-helpers==0.9.2``.
 
 Add ``django_cron.cron.FailedRunsNotificationCronJob`` to your ``CRON_CLASSES`` in settings file.
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ f.close()
 
 setup(
     name='django-cron',
-    version='0.6.0',
+    version='0.6.1',
     author='Sumit Chachra',
     author_email='chachra@tivix.com',
     url='http://github.com/tivix/django-cron',
@@ -29,7 +29,7 @@ setup(
     long_description=long_description,
     keywords='django cron',
     zip_safe=False,
-    install_requires=['Django>=3.2'],
+    install_requires=['Django>=3.2', 'django-common-helpers==0.9.2'],
     test_suite='runtests.runtests',
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
In the `0.6.0` release the dependency for `django-common-helpers` was removed but it is still used in [cron.py](https://github.com/Tivix/django-cron/blob/master/django_cron/cron.py#L3).

We ended up adding `django-common-helpers==0.9.2` in our own dependencies to fix the issue but thought it would be better to add it back here again.