### PR TITLE
Fix deprecation warning about `index_together`

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -30,4 +30,4 @@ jobs:
         pip install -r test_requirements.txt
     - name: Run Tests
       run: |
-        python runtests.py runtests
+        python -Wall runtests.py runtests

--- a/django_cron/migrations/0004_migrate_index_together_to_indexes.py
+++ b/django_cron/migrations/0004_migrate_index_together_to_indexes.py
@@ -1,0 +1,26 @@
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_cron", "0003_cronjoblock"),
+    ]
+
+    operations = [
+        migrations.RenameIndex(
+            model_name="cronjoblog",
+            new_name="django_cron_code_89ad04_idx",
+            old_fields=("code", "is_success", "ran_at_time"),
+        ),
+        migrations.RenameIndex(
+            model_name="cronjoblog",
+            new_name="django_cron_code_966ed3_idx",
+            old_fields=("code", "start_time"),
+        ),
+        migrations.RenameIndex(
+            model_name="cronjoblog",
+            new_name="django_cron_code_21f381_idx",
+            old_fields=("code", "start_time", "ran_at_time"),
+        ),
+    ]

--- a/django_cron/models.py
+++ b/django_cron/models.py
@@ -24,13 +24,11 @@ class CronJobLog(models.Model):
         return "%s (%s)" % (self.code, "Success" if self.is_success else "Fail")
 
     class Meta:
-        index_together = [
-            ('code', 'is_success', 'ran_at_time'),
-            ('code', 'start_time', 'ran_at_time'),
-            (
-                'code',
-                'start_time',
-            ),  # useful when finding latest run (order by start_time) of cron
+        indexes = [
+            models.Index(fields=['code', 'is_success', 'ran_at_time']),
+            models.Index(fields=['code', 'start_time', 'ran_at_time']),
+            # useful when finding latest run (order by start_time) of cron
+            models.Index(fields=['code', 'start_time']),
         ]
         app_label = 'django_cron'
 


### PR DESCRIPTION
Running tests with warning enabled on a recent version of Django logs:

```
RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'django_cron.CronJobLog' instead.
```

- [x] Run CI with warnings enabled
- [x] Fix deprecation warning