### PR TITLE
Add Python 3.10 and 3.11 to the CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version:
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Split array on multiple lines to reduce the chance of merge conflict & quoted all versions for consistency (quoting is required for Python 3.10).