### PR TITLE
Update cron.py to remove import of missing dependency

### DIFF
--- a/django_cron/cron.py
+++ b/django_cron/cron.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-
-from django_common.helper import send_mail
+from django.core.mail import send_mail
 
 from django_cron import CronJobBase, Schedule, get_class
 from django_cron.models import CronJobLog

--- a/django_cron/tests.py
+++ b/django_cron/tests.py
@@ -307,7 +307,6 @@ class TestRunCrons(TransactionTestCase):
     #     t.join(10)
     #     self.assertEqual(CronJobLog.objects.all().count(), logs_count + 1)
 
-    @skip  # TODO check why the test is failing
     def test_failed_runs_notification(self):
         CronJobLog.objects.all().delete()
 


### PR DESCRIPTION
This currently prevents `FailedRunsNotificationCronJob` from running.

Fixes #245