### PR TITLE
Meta.index_together to Meta.indexes on CronJobLog model.

### DIFF
--- a/django_cron/models.py
+++ b/django_cron/models.py
@@ -24,13 +24,10 @@ class CronJobLog(models.Model):
         return "%s (%s)" % (self.code, "Success" if self.is_success else "Fail")
 
     class Meta:
-        index_together = [
-            ('code', 'is_success', 'ran_at_time'),
-            ('code', 'start_time', 'ran_at_time'),
-            (
-                'code',
-                'start_time',
-            ),  # useful when finding latest run (order by start_time) of cron
+        indexes = [
+            models.Index(fields=['code', 'is_success', 'ran_at_time']),
+            models.Index(fields=['code', 'start_time', 'ran_at_time']),
+            models.Index(fields=['code', 'start_time']),
         ]
         app_label = 'django_cron'
 


### PR DESCRIPTION
Minimal fix for Django 5.1 compatibility. Meta.index_together is deprecated in this version, so it is replaced for Meta.indexes on the CronJobLog model.