### PR TITLE
Fix index_together

### DIFF
--- a/django_cron/models.py
+++ b/django_cron/models.py
@@ -24,14 +24,10 @@ class CronJobLog(models.Model):
         return "%s (%s)" % (self.code, "Success" if self.is_success else "Fail")
 
     class Meta:
-        index_together = [
-            ('code', 'is_success', 'ran_at_time'),
-            ('code', 'start_time', 'ran_at_time'),
-            (
-                'code',
-                'start_time',
-            ),  # useful when finding latest run (order by start_time) of cron
-        ]
+        indexes = [models.Index(fields=["code", "is_success", "ran_at_time"]),
+                   models.Index(fields=["code", "start_time", "ran_at_time"]),
+                   models.Index(fields=["code", "start_time"])]
+        # useful when finding latest run (order by start_time) of cron
         app_label = 'django_cron'
 
 


### PR DESCRIPTION
Class Meta option index_together in Django is deprecated: https://docs.djangoproject.com/en/5.1/r…eleases/4.2/#index-together-option-is-deprecated-in-favor-of-indexes. index_together was replaced with indexes in models.py